### PR TITLE
Unicode 17 update 🫈

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
 
             -   name: Download Noto Emoji font
                 run: |
-                    curl --location --output wwwassets/fonts/NotoColorEmoji-Regular.ttf https://github.com/google/fonts/raw/refs/heads/main/ofl/notocoloremoji/NotoColorEmoji-Regular.ttf
+                    curl --location --output wwwassets/fonts/NotoColorEmoji-Regular.ttf https://github.com/googlefonts/noto-emoji/raw/refs/heads/main/fonts/Noto-COLRv1.ttf
 
             -   name: Create release ZIP (excluding node_modules)
                 run: |

--- a/App.ahk
+++ b/App.ahk
@@ -33,9 +33,7 @@ A_TrayMenu.Add("E&xit", ActExit)
 A_TrayMenu.Default := "&Show"
 
 ; Folder in https://unicode.org/Public/
-UCD_VERSION := "16.0.0"
-; Folder in https://unicode.org/Public/emoji/
-EMOJI_VERSION := "16.0"
+UCD_VERSION := "17.0.0"
 ; Tag in https://github.com/unicode-org/cldr-json/tags
 CLDR_VERSION := "47.0.0"
 
@@ -46,7 +44,7 @@ if (!FileExist("hotkey.ahk")) {
 }
 
 LOCAL_FALLBACK_FONT_PATH := "wwwassets/fonts/NotoColorEmoji-Regular.ttf"
-LOCAL_FALLBACK_FONT_SIZE := 24274080  ; v2.047
+LOCAL_FALLBACK_FONT_SIZE := 25096376  ; v2.051
 if (!FileExist(LOCAL_FALLBACK_FONT_PATH)) {
     ans := MsgBox("The Noto Color Emoji font is not present in the wwwassets\fonts folder.`nIt is required to display emoji that are not available on your system.`n`nDo you want to download it now?", "Fallback font missing", "YesNo")
     if (ans = "Yes") {
@@ -57,6 +55,7 @@ if (!FileExist(LOCAL_FALLBACK_FONT_PATH)) {
 } else if (FileGetSize(LOCAL_FALLBACK_FONT_PATH) < LOCAL_FALLBACK_FONT_SIZE) {
     ans := MsgBox("It seems that you are using an old version of the Noto Color Emoji font in the wwwassets\fonts folder.`nIt is required to display emoji that are not available on your system.`n`nDo you want to download it now?", "Outdated fallback font", "YesNo")
     if (ans = "Yes") {
+        FileDelete(LOCAL_FALLBACK_FONT_PATH)
 		Download("https://github.com/google/fonts/raw/refs/heads/main/ofl/notocoloremoji/NotoColorEmoji-Regular.ttf", LOCAL_FALLBACK_FONT_PATH ".tmp")
 		FileMove(LOCAL_FALLBACK_FONT_PATH ".tmp", LOCAL_FALLBACK_FONT_PATH)
         MsgBox("The font has been downloaded successfully!", "Outdated fallback font")
@@ -199,7 +198,7 @@ class EmojiKeyboard {
         }
         onDownloadUnicode(num) {
             try {
-                this.DataUnicode('emoji/' EMOJI_VERSION '/emoji-test.txt')
+                this.DataUnicode(UCD_VERSION '/emoji/emoji-test.txt')
                 this.DataUnicode(UCD_VERSION '/ucd/emoji/emoji-data.txt')
                 this.DataUnicode(UCD_VERSION '/ucd/UnicodeData.txt')
                 this.DataUnicode(UCD_VERSION '/ucd/NamesList.txt')
@@ -214,7 +213,6 @@ class EmojiKeyboard {
 		onVersions() {
 			return {
 				ucd: UCD_VERSION,
-				emoji: EMOJI_VERSION,
 				cldr: CLDR_VERSION,
 			}
 		}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Emoji Keyboard (Emoji 16)
+Emoji Keyboard (Emoji 17)
 ==============
 [💾 Download](https://github.com/gilleswaeber/emoji-keyboard/releases/latest/download/emoji-keyboard.zip) *or see instructions below for cloning*
 

--- a/lib/opentype.ahk
+++ b/lib/opentype.ahk
@@ -1,0 +1,82 @@
+; Functions for reading the version of an OpenType Font
+; Specification here: https://learn.microsoft.com/en-us/typography/opentype/spec/otff
+; Note that AHK NumGet is little-endian while the OpenType specification uses big endian
+; 
+; Format overview (big endian, no padding)
+; Font: {
+;   TableDirectory: {
+;     uint32  sfntVersion    0x00010000 or 0x4F54544F
+;     uint16  numTables      number of tables
+;     uint16  searchRange    (historical)
+;     uint16  entrySelector  (historical)
+;     uint16  rangeShift
+;     TableRecord[numTables]: {
+;       char[4]  tag       table identifier
+;       uint32   checksum
+;       uint32   offset    from the beginning of the file
+;       uint32   length
+;     }
+;   }
+;   Table[numTables]: FontHeaderTable | ...
+; }
+;
+; FontHeaderTable: {  required, tag=head
+;   uint16   majorVersion
+;   uint16   minorVersion
+;   fixed32  fontRevision
+;   ...
+; }
+;
+; fixed32 is a 32-bit signed fixed-point number (value = (int32) fixed / 2¹⁶)
+;
+#Requires AutoHotkey 2.0
+
+GetFontVersion(fontFile) {
+	fontData := FileRead(fontFile, "RAW")
+
+	readU16(offset) {
+		v := NumGet(fontData, offset, "UChar") * 0x100
+		v := v + NumGet(fontData, offset + 1, "UChar")
+		Return v
+	}
+	readU32(offset) {
+		v := NumGet(fontData, offset, "UChar") * 0x1000000
+		v := v + NumGet(fontData, offset + 1, "UChar") * 0x10000
+		v := v + NumGet(fontData, offset + 2, "UChar") * 0x100
+		v := v + NumGet(fontData, offset + 3, "UChar")
+		Return v
+	}
+
+	sfntVersion := readU32(0)
+	if (sfntVersion != 0x00010000 and sfntVersion != 0x4F54544F) {  ; not a valid OTF file
+		Return Map("success", false, "error", "invalid font version " . sfntVersion)
+	}
+	numTables := readU16(0x04)
+	if (numTables > 32) {  ; too many tables
+		Return Map("success", false, "error", "invalid number of tables " . numTables)
+	}
+
+	headOffset := 0
+	Loop numTables {
+		tableOffset := 0x0C + (A_Index - 1) * 0x10
+		tag := ""
+		Loop 4 {
+			tag := tag . Chr(NumGet(fontData, tableOffset + A_Index - 1, "UChar"))
+		}
+		if (tag = "head") {
+			headOffset := readU32(tableOffset + 0x8)
+			Break
+		}
+	}
+
+	if (headOffset = 0) {  ; head table not found
+		MsgBox("No head table found in font file, " . fontFile)
+		Return Map("success", false, "error", "no head table found")
+	}
+
+	majorVersion := readU16(headOffset)
+	minorVersion := readU16(headOffset + 0x2)
+	fontRevisionRaw := readU32(headOffset + 0x4)
+	fontRevision := Round(fontRevisionRaw / 65536.0, 3)
+	Return Map("success", true, "major", majorVersion, "minor", minorVersion, "revision", fontRevision)
+}

--- a/wwwassets/package-lock.json
+++ b/wwwassets/package-lock.json
@@ -10,14 +10,14 @@
 			"license": "MIT",
 			"dependencies": {
 				"memoize-one": "^6.0.0",
-				"peggy": "^4.2.0",
-				"preact": "^10.26.5"
+				"peggy": "^5.0.6",
+				"preact": "^10.27.2"
 			},
 			"devDependencies": {
-				"@types/react": "^19.1.1",
-				"@types/react-dom": "^19.1.2",
-				"typescript": "^5.8.3",
-				"vite": "^6.2.6"
+				"@types/react": "^19.1.13",
+				"@types/react-dom": "^19.1.9",
+				"typescript": "^5.9.2",
+				"vite": "^7.1.7"
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
@@ -446,21 +446,21 @@
 			}
 		},
 		"node_modules/@peggyjs/from-mem": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/@peggyjs/from-mem/-/from-mem-1.3.5.tgz",
-			"integrity": "sha512-oRyzXE7nirAn+5yYjCdWQHg3EG2XXcYRoYNOK8Quqnmm+9FyK/2YWVunwudlYl++M3xY+gIAdf0vAYS+p0nKfQ==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@peggyjs/from-mem/-/from-mem-3.1.1.tgz",
+			"integrity": "sha512-m5OEjgJaePWpyNtQCvRZkpLoV+z44eh6QIO9yEwQuOThdUdkECO3wcKLT3tFA3H8WM5bxU/K/dpmo7r/X16UEw==",
 			"license": "MIT",
 			"dependencies": {
-				"semver": "7.6.3"
+				"semver": "7.7.2"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20.8"
 			}
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
-			"version": "4.39.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.39.0.tgz",
-			"integrity": "sha512-lGVys55Qb00Wvh8DMAocp5kIcaNzEFTmGhfFd88LfaogYTRKrdxgtlO5H6S49v2Nd8R2C6wLOal0qv6/kCkOwA==",
+			"version": "4.52.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.2.tgz",
+			"integrity": "sha512-o3pcKzJgSGt4d74lSZ+OCnHwkKBeAbFDmbEm5gg70eA8VkyCuC/zV9TwBnmw6VjDlRdF4Pshfb+WE9E6XY1PoQ==",
 			"cpu": [
 				"arm"
 			],
@@ -472,9 +472,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-android-arm64": {
-			"version": "4.39.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.39.0.tgz",
-			"integrity": "sha512-It9+M1zE31KWfqh/0cJLrrsCPiF72PoJjIChLX+rEcujVRCb4NLQ5QzFkzIZW8Kn8FTbvGQBY5TkKBau3S8cCQ==",
+			"version": "4.52.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.2.tgz",
+			"integrity": "sha512-cqFSWO5tX2vhC9hJTK8WAiPIm4Q8q/cU8j2HQA0L3E1uXvBYbOZMhE2oFL8n2pKB5sOCHY6bBuHaRwG7TkfJyw==",
 			"cpu": [
 				"arm64"
 			],
@@ -486,9 +486,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-arm64": {
-			"version": "4.39.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.39.0.tgz",
-			"integrity": "sha512-lXQnhpFDOKDXiGxsU9/l8UEGGM65comrQuZ+lDcGUx+9YQ9dKpF3rSEGepyeR5AHZ0b5RgiligsBhWZfSSQh8Q==",
+			"version": "4.52.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.2.tgz",
+			"integrity": "sha512-vngduywkkv8Fkh3wIZf5nFPXzWsNsVu1kvtLETWxTFf/5opZmflgVSeLgdHR56RQh71xhPhWoOkEBvbehwTlVA==",
 			"cpu": [
 				"arm64"
 			],
@@ -500,9 +500,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-x64": {
-			"version": "4.39.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.39.0.tgz",
-			"integrity": "sha512-mKXpNZLvtEbgu6WCkNij7CGycdw9cJi2k9v0noMb++Vab12GZjFgUXD69ilAbBh034Zwn95c2PNSz9xM7KYEAQ==",
+			"version": "4.52.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.2.tgz",
+			"integrity": "sha512-h11KikYrUCYTrDj6h939hhMNlqU2fo/X4NB0OZcys3fya49o1hmFaczAiJWVAFgrM1NCP6RrO7lQKeVYSKBPSQ==",
 			"cpu": [
 				"x64"
 			],
@@ -514,9 +514,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-freebsd-arm64": {
-			"version": "4.39.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.39.0.tgz",
-			"integrity": "sha512-jivRRlh2Lod/KvDZx2zUR+I4iBfHcu2V/BA2vasUtdtTN2Uk3jfcZczLa81ESHZHPHy4ih3T/W5rPFZ/hX7RtQ==",
+			"version": "4.52.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.2.tgz",
+			"integrity": "sha512-/eg4CI61ZUkLXxMHyVlmlGrSQZ34xqWlZNW43IAU4RmdzWEx0mQJ2mN/Cx4IHLVZFL6UBGAh+/GXhgvGb+nVxw==",
 			"cpu": [
 				"arm64"
 			],
@@ -528,9 +528,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-freebsd-x64": {
-			"version": "4.39.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.39.0.tgz",
-			"integrity": "sha512-8RXIWvYIRK9nO+bhVz8DwLBepcptw633gv/QT4015CpJ0Ht8punmoHU/DuEd3iw9Hr8UwUV+t+VNNuZIWYeY7Q==",
+			"version": "4.52.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.2.tgz",
+			"integrity": "sha512-QOWgFH5X9+p+S1NAfOqc0z8qEpJIoUHf7OWjNUGOeW18Mx22lAUOiA9b6r2/vpzLdfxi/f+VWsYjUOMCcYh0Ng==",
 			"cpu": [
 				"x64"
 			],
@@ -542,9 +542,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-			"version": "4.39.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.39.0.tgz",
-			"integrity": "sha512-mz5POx5Zu58f2xAG5RaRRhp3IZDK7zXGk5sdEDj4o96HeaXhlUwmLFzNlc4hCQi5sGdR12VDgEUqVSHer0lI9g==",
+			"version": "4.52.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.2.tgz",
+			"integrity": "sha512-kDWSPafToDd8LcBYd1t5jw7bD5Ojcu12S3uT372e5HKPzQt532vW+rGFFOaiR0opxePyUkHrwz8iWYEyH1IIQA==",
 			"cpu": [
 				"arm"
 			],
@@ -556,9 +556,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
-			"version": "4.39.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.39.0.tgz",
-			"integrity": "sha512-+YDwhM6gUAyakl0CD+bMFpdmwIoRDzZYaTWV3SDRBGkMU/VpIBYXXEvkEcTagw/7VVkL2vA29zU4UVy1mP0/Yw==",
+			"version": "4.52.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.2.tgz",
+			"integrity": "sha512-gKm7Mk9wCv6/rkzwCiUC4KnevYhlf8ztBrDRT9g/u//1fZLapSRc+eDZj2Eu2wpJ+0RzUKgtNijnVIB4ZxyL+w==",
 			"cpu": [
 				"arm"
 			],
@@ -570,9 +570,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-gnu": {
-			"version": "4.39.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.39.0.tgz",
-			"integrity": "sha512-EKf7iF7aK36eEChvlgxGnk7pdJfzfQbNvGV/+l98iiMwU23MwvmV0Ty3pJ0p5WQfm3JRHOytSIqD9LB7Bq7xdQ==",
+			"version": "4.52.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.2.tgz",
+			"integrity": "sha512-66lA8vnj5mB/rtDNwPgrrKUOtCLVQypkyDa2gMfOefXK6rcZAxKLO9Fy3GkW8VkPnENv9hBkNOFfGLf6rNKGUg==",
 			"cpu": [
 				"arm64"
 			],
@@ -584,9 +584,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-musl": {
-			"version": "4.39.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.39.0.tgz",
-			"integrity": "sha512-vYanR6MtqC7Z2SNr8gzVnzUul09Wi1kZqJaek3KcIlI/wq5Xtq4ZPIZ0Mr/st/sv/NnaPwy/D4yXg5x0B3aUUA==",
+			"version": "4.52.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.2.tgz",
+			"integrity": "sha512-s+OPucLNdJHvuZHuIz2WwncJ+SfWHFEmlC5nKMUgAelUeBUnlB4wt7rXWiyG4Zn07uY2Dd+SGyVa9oyLkVGOjA==",
 			"cpu": [
 				"arm64"
 			],
@@ -597,10 +597,10 @@
 				"linux"
 			]
 		},
-		"node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-			"version": "4.39.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.39.0.tgz",
-			"integrity": "sha512-NMRUT40+h0FBa5fb+cpxtZoGAggRem16ocVKIv5gDB5uLDgBIwrIsXlGqYbLwW8YyO3WVTk1FkFDjMETYlDqiw==",
+		"node_modules/@rollup/rollup-linux-loong64-gnu": {
+			"version": "4.52.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.2.tgz",
+			"integrity": "sha512-8wTRM3+gVMDLLDdaT6tKmOE3lJyRy9NpJUS/ZRWmLCmOPIJhVyXwjBo+XbrrwtV33Em1/eCTd5TuGJm4+DmYjw==",
 			"cpu": [
 				"loong64"
 			],
@@ -611,10 +611,10 @@
 				"linux"
 			]
 		},
-		"node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-			"version": "4.39.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.39.0.tgz",
-			"integrity": "sha512-0pCNnmxgduJ3YRt+D+kJ6Ai/r+TaePu9ZLENl+ZDV/CdVczXl95CbIiwwswu4L+K7uOIGf6tMo2vm8uadRaICQ==",
+		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
+			"version": "4.52.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.2.tgz",
+			"integrity": "sha512-6yqEfgJ1anIeuP2P/zhtfBlDpXUb80t8DpbYwXQ3bQd95JMvUaqiX+fKqYqUwZXqdJDd8xdilNtsHM2N0cFm6A==",
 			"cpu": [
 				"ppc64"
 			],
@@ -626,9 +626,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
-			"version": "4.39.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.39.0.tgz",
-			"integrity": "sha512-t7j5Zhr7S4bBtksT73bO6c3Qa2AV/HqiGlj9+KB3gNF5upcVkx+HLgxTm8DK4OkzsOYqbdqbLKwvGMhylJCPhQ==",
+			"version": "4.52.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.2.tgz",
+			"integrity": "sha512-sshYUiYVSEI2B6dp4jMncwxbrUqRdNApF2c3bhtLAU0qA8Lrri0p0NauOsTWh3yCCCDyBOjESHMExonp7Nzc0w==",
 			"cpu": [
 				"riscv64"
 			],
@@ -640,9 +640,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-musl": {
-			"version": "4.39.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.39.0.tgz",
-			"integrity": "sha512-m6cwI86IvQ7M93MQ2RF5SP8tUjD39Y7rjb1qjHgYh28uAPVU8+k/xYWvxRO3/tBN2pZkSMa5RjnPuUIbrwVxeA==",
+			"version": "4.52.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.2.tgz",
+			"integrity": "sha512-duBLgd+3pqC4MMwBrKkFxaZerUxZcYApQVC5SdbF5/e/589GwVvlRUnyqMFbM8iUSb1BaoX/3fRL7hB9m2Pj8Q==",
 			"cpu": [
 				"riscv64"
 			],
@@ -654,9 +654,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-s390x-gnu": {
-			"version": "4.39.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.39.0.tgz",
-			"integrity": "sha512-iRDJd2ebMunnk2rsSBYlsptCyuINvxUfGwOUldjv5M4tpa93K8tFMeYGpNk2+Nxl+OBJnBzy2/JCscGeO507kA==",
+			"version": "4.52.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.2.tgz",
+			"integrity": "sha512-tzhYJJidDUVGMgVyE+PmxENPHlvvqm1KILjjZhB8/xHYqAGeizh3GBGf9u6WdJpZrz1aCpIIHG0LgJgH9rVjHQ==",
 			"cpu": [
 				"s390x"
 			],
@@ -668,9 +668,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-gnu": {
-			"version": "4.39.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.39.0.tgz",
-			"integrity": "sha512-t9jqYw27R6Lx0XKfEFe5vUeEJ5pF3SGIM6gTfONSMb7DuG6z6wfj2yjcoZxHg129veTqU7+wOhY6GX8wmf90dA==",
+			"version": "4.52.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.2.tgz",
+			"integrity": "sha512-opH8GSUuVcCSSyHHcl5hELrmnk4waZoVpgn/4FDao9iyE4WpQhyWJ5ryl5M3ocp4qkRuHfyXnGqg8M9oKCEKRA==",
 			"cpu": [
 				"x64"
 			],
@@ -682,9 +682,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-musl": {
-			"version": "4.39.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.39.0.tgz",
-			"integrity": "sha512-ThFdkrFDP55AIsIZDKSBWEt/JcWlCzydbZHinZ0F/r1h83qbGeenCt/G/wG2O0reuENDD2tawfAj2s8VK7Bugg==",
+			"version": "4.52.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.2.tgz",
+			"integrity": "sha512-LSeBHnGli1pPKVJ79ZVJgeZWWZXkEe/5o8kcn23M8eMKCUANejchJbF/JqzM4RRjOJfNRhKJk8FuqL1GKjF5oQ==",
 			"cpu": [
 				"x64"
 			],
@@ -695,10 +695,24 @@
 				"linux"
 			]
 		},
+		"node_modules/@rollup/rollup-openharmony-arm64": {
+			"version": "4.52.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.2.tgz",
+			"integrity": "sha512-uPj7MQ6/s+/GOpolavm6BPo+6CbhbKYyZHUDvZ/SmJM7pfDBgdGisFX3bY/CBDMg2ZO4utfhlApkSfZ92yXw7Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			]
+		},
 		"node_modules/@rollup/rollup-win32-arm64-msvc": {
-			"version": "4.39.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.39.0.tgz",
-			"integrity": "sha512-jDrLm6yUtbOg2TYB3sBF3acUnAwsIksEYjLeHL+TJv9jg+TmTwdyjnDex27jqEMakNKf3RwwPahDIt7QXCSqRQ==",
+			"version": "4.52.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.2.tgz",
+			"integrity": "sha512-Z9MUCrSgIaUeeHAiNkm3cQyst2UhzjPraR3gYYfOjAuZI7tcFRTOD+4cHLPoS/3qinchth+V56vtqz1Tv+6KPA==",
 			"cpu": [
 				"arm64"
 			],
@@ -710,9 +724,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-ia32-msvc": {
-			"version": "4.39.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.39.0.tgz",
-			"integrity": "sha512-6w9uMuza+LbLCVoNKL5FSLE7yvYkq9laSd09bwS0tMjkwXrmib/4KmoJcrKhLWHvw19mwU+33ndC69T7weNNjQ==",
+			"version": "4.52.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.2.tgz",
+			"integrity": "sha512-+GnYBmpjldD3XQd+HMejo+0gJGwYIOfFeoBQv32xF/RUIvccUz20/V6Otdv+57NE70D5pa8W/jVGDoGq0oON4A==",
 			"cpu": [
 				"ia32"
 			],
@@ -723,10 +737,24 @@
 				"win32"
 			]
 		},
+		"node_modules/@rollup/rollup-win32-x64-gnu": {
+			"version": "4.52.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.2.tgz",
+			"integrity": "sha512-ApXFKluSB6kDQkAqZOKXBjiaqdF1BlKi+/eqnYe9Ee7U2K3pUDKsIyr8EYm/QDHTJIM+4X+lI0gJc3TTRhd+dA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
 		"node_modules/@rollup/rollup-win32-x64-msvc": {
-			"version": "4.39.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.39.0.tgz",
-			"integrity": "sha512-yAkUOkIKZlK5dl7u6dg897doBgLXmUHhIINM2c+sND3DZwnrdQkkSiDh7N75Ll4mM4dxSkYfXqU9fW3lLkMFug==",
+			"version": "4.52.2",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.2.tgz",
+			"integrity": "sha512-ARz+Bs8kY6FtitYM96PqPEVvPXqEZmPZsSkXvyX19YzDqkCaIlhCieLLMI5hxO9SRZ2XtCtm8wxhy0iJ2jxNfw==",
 			"cpu": [
 				"x64"
 			],
@@ -738,16 +766,16 @@
 			]
 		},
 		"node_modules/@types/estree": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
-			"integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/react": {
-			"version": "19.1.1",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.1.tgz",
-			"integrity": "sha512-ePapxDL7qrgqSF67s0h9m412d9DbXyC1n59O2st+9rjuuamWsZuD2w55rqY12CbzsZ7uVXb5Nw0gEp9Z8MMutQ==",
+			"version": "19.1.13",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.13.tgz",
+			"integrity": "sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -755,9 +783,9 @@
 			}
 		},
 		"node_modules/@types/react-dom": {
-			"version": "19.1.2",
-			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.2.tgz",
-			"integrity": "sha512-XGJkWF41Qq305SKWEILa1O8vzhb3aOo3ogBlSmiqNko/WmRb6QIaweuZCXjKygVDXpzXb5wyxKTSOsmkuqj+Qw==",
+			"version": "19.1.9",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.9.tgz",
+			"integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
@@ -765,12 +793,12 @@
 			}
 		},
 		"node_modules/commander": {
-			"version": "12.1.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-			"integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+			"version": "14.0.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-14.0.1.tgz",
+			"integrity": "sha512-2JkV3gUZUVrbNA+1sjBOYLsMZ5cEEl8GTFP2a4AVz5hvasAMCQ1D2l2le/cX+pV4N6ZU17zjUahLpIXRrnWL8A==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			}
 		},
 		"node_modules/csstype": {
@@ -819,6 +847,24 @@
 				"@esbuild/win32-x64": "0.25.2"
 			}
 		},
+		"node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/fsevents": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -858,20 +904,20 @@
 			}
 		},
 		"node_modules/peggy": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/peggy/-/peggy-4.2.0.tgz",
-			"integrity": "sha512-ZjzyJYY8NqW8JOZr2PbS/J0UH/hnfGALxSDsBUVQg5Y/I+ZaPuGeBJ7EclUX2RvWjhlsi4pnuL1C/K/3u+cDeg==",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/peggy/-/peggy-5.0.6.tgz",
+			"integrity": "sha512-Sud8Zus0JAgE+U4zwkJv29OOaXhviFI7J90/6cGfy3OoqR8dpnieeF9a46dj0bTtqiFnrFatldA6ltQyOJvNmg==",
 			"license": "MIT",
 			"dependencies": {
-				"@peggyjs/from-mem": "1.3.5",
-				"commander": "^12.1.0",
-				"source-map-generator": "0.8.0"
+				"@peggyjs/from-mem": "3.1.1",
+				"commander": "^14.0.0",
+				"source-map-generator": "2.0.2"
 			},
 			"bin": {
 				"peggy": "bin/peggy.js"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			}
 		},
 		"node_modules/picocolors": {
@@ -881,10 +927,23 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/picomatch": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
 		"node_modules/postcss": {
-			"version": "8.5.3",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
-			"integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+			"version": "8.5.6",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+			"integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
 			"dev": true,
 			"funding": [
 				{
@@ -902,7 +961,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.8",
+				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},
@@ -911,9 +970,9 @@
 			}
 		},
 		"node_modules/preact": {
-			"version": "10.26.5",
-			"resolved": "https://registry.npmjs.org/preact/-/preact-10.26.5.tgz",
-			"integrity": "sha512-fmpDkgfGU6JYux9teDWLhj9mKN55tyepwYbxHgQuIxbWQzgFg5vk7Mrrtfx7xRxq798ynkY4DDDxZr235Kk+4w==",
+			"version": "10.27.2",
+			"resolved": "https://registry.npmjs.org/preact/-/preact-10.27.2.tgz",
+			"integrity": "sha512-5SYSgFKSyhCbk6SrXyMpqjb5+MQBgfvEKE/OC+PujcY34sOpqtr+0AZQtPYx5IA6VxynQ7rUPCtKzyovpj9Bpg==",
 			"license": "MIT",
 			"funding": {
 				"type": "opencollective",
@@ -921,13 +980,13 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "4.39.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.39.0.tgz",
-			"integrity": "sha512-thI8kNc02yNvnmJp8dr3fNWJ9tCONDhp6TV35X6HkKGGs9E6q7YWCHbe5vKiTa7TAiNcFEmXKj3X/pG2b3ci0g==",
+			"version": "4.52.2",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.2.tgz",
+			"integrity": "sha512-I25/2QgoROE1vYV+NQ1En9T9UFB9Cmfm2CJ83zZOlaDpvz29wGQSZXWKw7MiNXau7wYgB/T9fVIdIuEQ+KbiiA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@types/estree": "1.0.7"
+				"@types/estree": "1.0.8"
 			},
 			"bin": {
 				"rollup": "dist/bin/rollup"
@@ -937,33 +996,35 @@
 				"npm": ">=8.0.0"
 			},
 			"optionalDependencies": {
-				"@rollup/rollup-android-arm-eabi": "4.39.0",
-				"@rollup/rollup-android-arm64": "4.39.0",
-				"@rollup/rollup-darwin-arm64": "4.39.0",
-				"@rollup/rollup-darwin-x64": "4.39.0",
-				"@rollup/rollup-freebsd-arm64": "4.39.0",
-				"@rollup/rollup-freebsd-x64": "4.39.0",
-				"@rollup/rollup-linux-arm-gnueabihf": "4.39.0",
-				"@rollup/rollup-linux-arm-musleabihf": "4.39.0",
-				"@rollup/rollup-linux-arm64-gnu": "4.39.0",
-				"@rollup/rollup-linux-arm64-musl": "4.39.0",
-				"@rollup/rollup-linux-loongarch64-gnu": "4.39.0",
-				"@rollup/rollup-linux-powerpc64le-gnu": "4.39.0",
-				"@rollup/rollup-linux-riscv64-gnu": "4.39.0",
-				"@rollup/rollup-linux-riscv64-musl": "4.39.0",
-				"@rollup/rollup-linux-s390x-gnu": "4.39.0",
-				"@rollup/rollup-linux-x64-gnu": "4.39.0",
-				"@rollup/rollup-linux-x64-musl": "4.39.0",
-				"@rollup/rollup-win32-arm64-msvc": "4.39.0",
-				"@rollup/rollup-win32-ia32-msvc": "4.39.0",
-				"@rollup/rollup-win32-x64-msvc": "4.39.0",
+				"@rollup/rollup-android-arm-eabi": "4.52.2",
+				"@rollup/rollup-android-arm64": "4.52.2",
+				"@rollup/rollup-darwin-arm64": "4.52.2",
+				"@rollup/rollup-darwin-x64": "4.52.2",
+				"@rollup/rollup-freebsd-arm64": "4.52.2",
+				"@rollup/rollup-freebsd-x64": "4.52.2",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.52.2",
+				"@rollup/rollup-linux-arm-musleabihf": "4.52.2",
+				"@rollup/rollup-linux-arm64-gnu": "4.52.2",
+				"@rollup/rollup-linux-arm64-musl": "4.52.2",
+				"@rollup/rollup-linux-loong64-gnu": "4.52.2",
+				"@rollup/rollup-linux-ppc64-gnu": "4.52.2",
+				"@rollup/rollup-linux-riscv64-gnu": "4.52.2",
+				"@rollup/rollup-linux-riscv64-musl": "4.52.2",
+				"@rollup/rollup-linux-s390x-gnu": "4.52.2",
+				"@rollup/rollup-linux-x64-gnu": "4.52.2",
+				"@rollup/rollup-linux-x64-musl": "4.52.2",
+				"@rollup/rollup-openharmony-arm64": "4.52.2",
+				"@rollup/rollup-win32-arm64-msvc": "4.52.2",
+				"@rollup/rollup-win32-ia32-msvc": "4.52.2",
+				"@rollup/rollup-win32-x64-gnu": "4.52.2",
+				"@rollup/rollup-win32-x64-msvc": "4.52.2",
 				"fsevents": "~2.3.2"
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.6.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -973,10 +1034,12 @@
 			}
 		},
 		"node_modules/source-map-generator": {
-			"version": "0.8.0",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/source-map-generator/-/source-map-generator-2.0.2.tgz",
+			"integrity": "sha512-unCl5BQhF/us51DiT7SvlSY3QUPhyfAdHJxd8l7FXdwzqxli0UDMV2dEuei2SeGp3Z4rB/AJ9zKi1mGOp2K2ww==",
 			"license": "BSD-3-Clause",
 			"engines": {
-				"node": ">= 10"
+				"node": ">=20"
 			}
 		},
 		"node_modules/source-map-js": {
@@ -989,10 +1052,27 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/tinyglobby": {
+			"version": "0.2.15",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+			"integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.3"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
 		"node_modules/typescript": {
-			"version": "5.8.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-			"integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+			"version": "5.9.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+			"integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -1004,21 +1084,24 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "6.2.6",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-6.2.6.tgz",
-			"integrity": "sha512-9xpjNl3kR4rVDZgPNdTL0/c6ao4km69a/2ihNQbcANz8RuCOK3hQBmLSJf3bRKVQjVMda+YvizNE8AwvogcPbw==",
+			"version": "7.1.7",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-7.1.7.tgz",
+			"integrity": "sha512-VbA8ScMvAISJNJVbRDTJdCwqQoAareR/wutevKanhR2/1EkoXVZVkkORaYm/tNVCjP/UDTKtcw3bAkwOUdedmA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"esbuild": "^0.25.0",
-				"postcss": "^8.5.3",
-				"rollup": "^4.30.1"
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.3",
+				"postcss": "^8.5.6",
+				"rollup": "^4.43.0",
+				"tinyglobby": "^0.2.15"
 			},
 			"bin": {
 				"vite": "bin/vite.js"
 			},
 			"engines": {
-				"node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+				"node": "^20.19.0 || >=22.12.0"
 			},
 			"funding": {
 				"url": "https://github.com/vitejs/vite?sponsor=1"
@@ -1027,14 +1110,14 @@
 				"fsevents": "~2.3.3"
 			},
 			"peerDependencies": {
-				"@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+				"@types/node": "^20.19.0 || >=22.12.0",
 				"jiti": ">=1.21.0",
-				"less": "*",
+				"less": "^4.0.0",
 				"lightningcss": "^1.21.0",
-				"sass": "*",
-				"sass-embedded": "*",
-				"stylus": "*",
-				"sugarss": "*",
+				"sass": "^1.70.0",
+				"sass-embedded": "^1.70.0",
+				"stylus": ">=0.54.8",
+				"sugarss": "^5.0.0",
 				"terser": "^5.16.0",
 				"tsx": "^4.8.1",
 				"yaml": "^2.4.2"

--- a/wwwassets/package-lock.json
+++ b/wwwassets/package-lock.json
@@ -11,19 +11,19 @@
 			"dependencies": {
 				"memoize-one": "^6.0.0",
 				"peggy": "^5.0.6",
-				"preact": "^10.27.2"
+				"preact": "^10.28.0"
 			},
 			"devDependencies": {
-				"@types/react": "^19.1.13",
-				"@types/react-dom": "^19.1.9",
-				"typescript": "^5.9.2",
-				"vite": "^7.1.7"
+				"@types/react": "^19.2.7",
+				"@types/react-dom": "^19.2.3",
+				"typescript": "^5.9.3",
+				"vite": "^7.3.0"
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.2.tgz",
-			"integrity": "sha512-wCIboOL2yXZym2cgm6mlA742s9QeJ8DjGVaL39dLN4rRwrOgOyYSnOaFPhKZGLb2ngj4EyfAFjsNJwPXZvseag==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
+			"integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
 			"cpu": [
 				"ppc64"
 			],
@@ -38,9 +38,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.2.tgz",
-			"integrity": "sha512-NQhH7jFstVY5x8CKbcfa166GoV0EFkaPkCKBQkdPJFvo5u+nGXLEH/ooniLb3QI8Fk58YAx7nsPLozUWfCBOJA==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
+			"integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
 			"cpu": [
 				"arm"
 			],
@@ -55,9 +55,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.2.tgz",
-			"integrity": "sha512-5ZAX5xOmTligeBaeNEPnPaeEuah53Id2tX4c2CVP3JaROTH+j4fnfHCkr1PjXMd78hMst+TlkfKcW/DlTq0i4w==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
+			"integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
 			"cpu": [
 				"arm64"
 			],
@@ -72,9 +72,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.2.tgz",
-			"integrity": "sha512-Ffcx+nnma8Sge4jzddPHCZVRvIfQ0kMsUsCMcJRHkGJ1cDmhe4SsrYIjLUKn1xpHZybmOqCWwB0zQvsjdEHtkg==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
+			"integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
 			"cpu": [
 				"x64"
 			],
@@ -89,9 +89,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.2.tgz",
-			"integrity": "sha512-MpM6LUVTXAzOvN4KbjzU/q5smzryuoNjlriAIx+06RpecwCkL9JpenNzpKd2YMzLJFOdPqBpuub6eVRP5IgiSA==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
+			"integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
 			"cpu": [
 				"arm64"
 			],
@@ -106,9 +106,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.2.tgz",
-			"integrity": "sha512-5eRPrTX7wFyuWe8FqEFPG2cU0+butQQVNcT4sVipqjLYQjjh8a8+vUTfgBKM88ObB85ahsnTwF7PSIt6PG+QkA==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
+			"integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
 			"cpu": [
 				"x64"
 			],
@@ -123,9 +123,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.2.tgz",
-			"integrity": "sha512-mLwm4vXKiQ2UTSX4+ImyiPdiHjiZhIaE9QvC7sw0tZ6HoNMjYAqQpGyui5VRIi5sGd+uWq940gdCbY3VLvsO1w==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
+			"integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
 			"cpu": [
 				"arm64"
 			],
@@ -140,9 +140,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.2.tgz",
-			"integrity": "sha512-6qyyn6TjayJSwGpm8J9QYYGQcRgc90nmfdUb0O7pp1s4lTY+9D0H9O02v5JqGApUyiHOtkz6+1hZNvNtEhbwRQ==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
+			"integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
 			"cpu": [
 				"x64"
 			],
@@ -157,9 +157,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.2.tgz",
-			"integrity": "sha512-UHBRgJcmjJv5oeQF8EpTRZs/1knq6loLxTsjc3nxO9eXAPDLcWW55flrMVc97qFPbmZP31ta1AZVUKQzKTzb0g==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
+			"integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
 			"cpu": [
 				"arm"
 			],
@@ -174,9 +174,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.2.tgz",
-			"integrity": "sha512-gq/sjLsOyMT19I8obBISvhoYiZIAaGF8JpeXu1u8yPv8BE5HlWYobmlsfijFIZ9hIVGYkbdFhEqC0NvM4kNO0g==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
+			"integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
 			"cpu": [
 				"arm64"
 			],
@@ -191,9 +191,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.2.tgz",
-			"integrity": "sha512-bBYCv9obgW2cBP+2ZWfjYTU+f5cxRoGGQ5SeDbYdFCAZpYWrfjjfYwvUpP8MlKbP0nwZ5gyOU/0aUzZ5HWPuvQ==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
+			"integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
 			"cpu": [
 				"ia32"
 			],
@@ -208,9 +208,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.2.tgz",
-			"integrity": "sha512-SHNGiKtvnU2dBlM5D8CXRFdd+6etgZ9dXfaPCeJtz+37PIUlixvlIhI23L5khKXs3DIzAn9V8v+qb1TRKrgT5w==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
+			"integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
 			"cpu": [
 				"loong64"
 			],
@@ -225,9 +225,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.2.tgz",
-			"integrity": "sha512-hDDRlzE6rPeoj+5fsADqdUZl1OzqDYow4TB4Y/3PlKBD0ph1e6uPHzIQcv2Z65u2K0kpeByIyAjCmjn1hJgG0Q==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
+			"integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
 			"cpu": [
 				"mips64el"
 			],
@@ -242,9 +242,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.2.tgz",
-			"integrity": "sha512-tsHu2RRSWzipmUi9UBDEzc0nLc4HtpZEI5Ba+Omms5456x5WaNuiG3u7xh5AO6sipnJ9r4cRWQB2tUjPyIkc6g==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
+			"integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -259,9 +259,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.2.tgz",
-			"integrity": "sha512-k4LtpgV7NJQOml/10uPU0s4SAXGnowi5qBSjaLWMojNCUICNu7TshqHLAEbkBdAszL5TabfvQ48kK84hyFzjnw==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
+			"integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
 			"cpu": [
 				"riscv64"
 			],
@@ -276,9 +276,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.2.tgz",
-			"integrity": "sha512-GRa4IshOdvKY7M/rDpRR3gkiTNp34M0eLTaC1a08gNrh4u488aPhuZOCpkF6+2wl3zAN7L7XIpOFBhnaE3/Q8Q==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
+			"integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
 			"cpu": [
 				"s390x"
 			],
@@ -293,9 +293,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.2.tgz",
-			"integrity": "sha512-QInHERlqpTTZ4FRB0fROQWXcYRD64lAoiegezDunLpalZMjcUcld3YzZmVJ2H/Cp0wJRZ8Xtjtj0cEHhYc/uUg==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
+			"integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
 			"cpu": [
 				"x64"
 			],
@@ -310,9 +310,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.2.tgz",
-			"integrity": "sha512-talAIBoY5M8vHc6EeI2WW9d/CkiO9MQJ0IOWX8hrLhxGbro/vBXJvaQXefW2cP0z0nQVTdQ/eNyGFV1GSKrxfw==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
+			"integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
 			"cpu": [
 				"arm64"
 			],
@@ -327,9 +327,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.2.tgz",
-			"integrity": "sha512-voZT9Z+tpOxrvfKFyfDYPc4DO4rk06qamv1a/fkuzHpiVBMOhpjK+vBmWM8J1eiB3OLSMFYNaOaBNLXGChf5tg==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
+			"integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
 			"cpu": [
 				"x64"
 			],
@@ -344,9 +344,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.2.tgz",
-			"integrity": "sha512-dcXYOC6NXOqcykeDlwId9kB6OkPUxOEqU+rkrYVqJbK2hagWOMrsTGsMr8+rW02M+d5Op5NNlgMmjzecaRf7Tg==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
+			"integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
 			"cpu": [
 				"arm64"
 			],
@@ -361,9 +361,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.2.tgz",
-			"integrity": "sha512-t/TkWwahkH0Tsgoq1Ju7QfgGhArkGLkF1uYz8nQS/PPFlXbP5YgRpqQR3ARRiC2iXoLTWFxc6DJMSK10dVXluw==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
+			"integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
 			"cpu": [
 				"x64"
 			],
@@ -377,10 +377,27 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
+			"integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.2.tgz",
-			"integrity": "sha512-cfZH1co2+imVdWCjd+D1gf9NjkchVhhdpgb1q5y6Hcv9TP6Zi9ZG/beI3ig8TvwT9lH9dlxLq5MQBBgwuj4xvA==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
+			"integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
 			"cpu": [
 				"x64"
 			],
@@ -395,9 +412,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.2.tgz",
-			"integrity": "sha512-7Loyjh+D/Nx/sOTzV8vfbB3GJuHdOQyrOryFdZvPHLf42Tk9ivBU5Aedi7iyX+x6rbn2Mh68T4qq1SDqJBQO5Q==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
+			"integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
 			"cpu": [
 				"arm64"
 			],
@@ -412,9 +429,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.2.tgz",
-			"integrity": "sha512-WRJgsz9un0nqZJ4MfhabxaD9Ft8KioqU3JMinOTvobbX6MOSUigSBlogP8QB3uxpJDsFS6yN+3FDBdqE5lg9kg==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
+			"integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
 			"cpu": [
 				"ia32"
 			],
@@ -429,9 +446,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.2.tgz",
-			"integrity": "sha512-kM3HKb16VIXZyIeVrM1ygYmZBKybX8N4p754bw390wGO3Tf2j4L2/WYL+4suWujpgf6GBYs3jv7TyUivdd05JA==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
+			"integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
 			"cpu": [
 				"x64"
 			],
@@ -773,23 +790,23 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/react": {
-			"version": "19.1.13",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.13.tgz",
-			"integrity": "sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==",
+			"version": "19.2.7",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
+			"integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"csstype": "^3.0.2"
+				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@types/react-dom": {
-			"version": "19.1.9",
-			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.9.tgz",
-			"integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
+			"version": "19.2.3",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+			"integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
-				"@types/react": "^19.0.0"
+				"@types/react": "^19.2.0"
 			}
 		},
 		"node_modules/commander": {
@@ -802,14 +819,16 @@
 			}
 		},
 		"node_modules/csstype": {
-			"version": "3.1.1",
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+			"integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/esbuild": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.2.tgz",
-			"integrity": "sha512-16854zccKPnC+toMywC+uKNeYSv+/eXkevRAfwRD/G9Cleq66m8XFIrigkbvauLLlCfDL45Q2cWegSg53gGBnQ==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
+			"integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -820,31 +839,32 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.25.2",
-				"@esbuild/android-arm": "0.25.2",
-				"@esbuild/android-arm64": "0.25.2",
-				"@esbuild/android-x64": "0.25.2",
-				"@esbuild/darwin-arm64": "0.25.2",
-				"@esbuild/darwin-x64": "0.25.2",
-				"@esbuild/freebsd-arm64": "0.25.2",
-				"@esbuild/freebsd-x64": "0.25.2",
-				"@esbuild/linux-arm": "0.25.2",
-				"@esbuild/linux-arm64": "0.25.2",
-				"@esbuild/linux-ia32": "0.25.2",
-				"@esbuild/linux-loong64": "0.25.2",
-				"@esbuild/linux-mips64el": "0.25.2",
-				"@esbuild/linux-ppc64": "0.25.2",
-				"@esbuild/linux-riscv64": "0.25.2",
-				"@esbuild/linux-s390x": "0.25.2",
-				"@esbuild/linux-x64": "0.25.2",
-				"@esbuild/netbsd-arm64": "0.25.2",
-				"@esbuild/netbsd-x64": "0.25.2",
-				"@esbuild/openbsd-arm64": "0.25.2",
-				"@esbuild/openbsd-x64": "0.25.2",
-				"@esbuild/sunos-x64": "0.25.2",
-				"@esbuild/win32-arm64": "0.25.2",
-				"@esbuild/win32-ia32": "0.25.2",
-				"@esbuild/win32-x64": "0.25.2"
+				"@esbuild/aix-ppc64": "0.27.2",
+				"@esbuild/android-arm": "0.27.2",
+				"@esbuild/android-arm64": "0.27.2",
+				"@esbuild/android-x64": "0.27.2",
+				"@esbuild/darwin-arm64": "0.27.2",
+				"@esbuild/darwin-x64": "0.27.2",
+				"@esbuild/freebsd-arm64": "0.27.2",
+				"@esbuild/freebsd-x64": "0.27.2",
+				"@esbuild/linux-arm": "0.27.2",
+				"@esbuild/linux-arm64": "0.27.2",
+				"@esbuild/linux-ia32": "0.27.2",
+				"@esbuild/linux-loong64": "0.27.2",
+				"@esbuild/linux-mips64el": "0.27.2",
+				"@esbuild/linux-ppc64": "0.27.2",
+				"@esbuild/linux-riscv64": "0.27.2",
+				"@esbuild/linux-s390x": "0.27.2",
+				"@esbuild/linux-x64": "0.27.2",
+				"@esbuild/netbsd-arm64": "0.27.2",
+				"@esbuild/netbsd-x64": "0.27.2",
+				"@esbuild/openbsd-arm64": "0.27.2",
+				"@esbuild/openbsd-x64": "0.27.2",
+				"@esbuild/openharmony-arm64": "0.27.2",
+				"@esbuild/sunos-x64": "0.27.2",
+				"@esbuild/win32-arm64": "0.27.2",
+				"@esbuild/win32-ia32": "0.27.2",
+				"@esbuild/win32-x64": "0.27.2"
 			}
 		},
 		"node_modules/fdir": {
@@ -970,9 +990,9 @@
 			}
 		},
 		"node_modules/preact": {
-			"version": "10.27.2",
-			"resolved": "https://registry.npmjs.org/preact/-/preact-10.27.2.tgz",
-			"integrity": "sha512-5SYSgFKSyhCbk6SrXyMpqjb5+MQBgfvEKE/OC+PujcY34sOpqtr+0AZQtPYx5IA6VxynQ7rUPCtKzyovpj9Bpg==",
+			"version": "10.28.0",
+			"resolved": "https://registry.npmjs.org/preact/-/preact-10.28.0.tgz",
+			"integrity": "sha512-rytDAoiXr3+t6OIP3WGlDd0ouCUG1iCWzkcY3++Nreuoi17y6T5i/zRhe6uYfoVcxq6YU+sBtJouuRDsq8vvqA==",
 			"license": "MIT",
 			"funding": {
 				"type": "opencollective",
@@ -1070,9 +1090,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.9.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-			"integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -1084,13 +1104,13 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "7.1.7",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-7.1.7.tgz",
-			"integrity": "sha512-VbA8ScMvAISJNJVbRDTJdCwqQoAareR/wutevKanhR2/1EkoXVZVkkORaYm/tNVCjP/UDTKtcw3bAkwOUdedmA==",
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.0.tgz",
+			"integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"esbuild": "^0.25.0",
+				"esbuild": "^0.27.0",
 				"fdir": "^6.5.0",
 				"picomatch": "^4.0.3",
 				"postcss": "^8.5.6",

--- a/wwwassets/package.json
+++ b/wwwassets/package.json
@@ -4,15 +4,15 @@
 	"author": "Gilles Waeber",
 	"license": "MIT",
 	"devDependencies": {
-		"@types/react": "^19.1.1",
-		"@types/react-dom": "^19.1.2",
-		"typescript": "^5.8.3",
-		"vite": "^6.2.6"
+		"@types/react": "^19.1.13",
+		"@types/react-dom": "^19.1.9",
+		"typescript": "^5.9.2",
+		"vite": "^7.1.7"
 	},
 	"dependencies": {
 		"memoize-one": "^6.0.0",
-		"peggy": "^4.2.0",
-		"preact": "^10.26.5"
+		"peggy": "^5.0.6",
+		"preact": "^10.27.2"
 	},
 	"scripts": {
 		"dev": "vite build --watch --sourcemap inline",

--- a/wwwassets/package.json
+++ b/wwwassets/package.json
@@ -4,15 +4,15 @@
 	"author": "Gilles Waeber",
 	"license": "MIT",
 	"devDependencies": {
-		"@types/react": "^19.1.13",
-		"@types/react-dom": "^19.1.9",
-		"typescript": "^5.9.2",
-		"vite": "^7.1.7"
+		"@types/react": "^19.2.7",
+		"@types/react-dom": "^19.2.3",
+		"typescript": "^5.9.3",
+		"vite": "^7.3.0"
 	},
 	"dependencies": {
 		"memoize-one": "^6.0.0",
 		"peggy": "^5.0.6",
-		"preact": "^10.27.2"
+		"preact": "^10.28.0"
 	},
 	"scripts": {
 		"dev": "vite build --watch --sourcemap inline",

--- a/wwwassets/script/ahk.ts
+++ b/wwwassets/script/ahk.ts
@@ -25,7 +25,6 @@ type HostObject = {
 };
 export type AhkVersions = {
 	cldr: string;
-	emoji: string;
 	ucd: string;
 };
 let AHK: HostObject | null = null;
@@ -88,7 +87,6 @@ export async function ahkVersions(): Promise<AhkVersions> {
 		const v = AHK!.versions();
 		return {
 			cldr: await v.cldr,
-			emoji: await v.emoji,
 			ucd: await v.ucd,
 		};
 	} else {

--- a/wwwassets/script/builder/builder.ts
+++ b/wwwassets/script/builder/builder.ts
@@ -29,7 +29,7 @@ async function buildAhk() {
 	await ahkDownloadUnicode();
 	const v = await ahkVersions();
 	const paths: Paths = {
-		emojiTestPath: `../res/data/emoji/${v.emoji}/emoji-test.txt`,
+		emojiTestPath: `../res/data/${v.ucd}/emoji/emoji-test.txt`,
 		emojiDataPath: `../res/data/${v.ucd}/ucd/emoji/emoji-data.txt`,
 		unicodeDataPath: `../res/data/${v.ucd}/ucd/UnicodeData.txt`,
 		namedSequencesPath: `../res/data/${v.ucd}/ucd/NamedSequences.txt`,

--- a/wwwassets/script/config/fallback.ts
+++ b/wwwassets/script/config/fallback.ts
@@ -40,6 +40,10 @@ export const IconFallback: {
 		]
 	},
 	{
+		requirement: {type: "emoji", emoji: "🫈"},  // Hairy Creature
+		version: new Version("17"),
+	},
+	{
 		requirement: {type: "emoji", emoji: "🪉"},  // Harp
 		version: new Version("16"),
 	},

--- a/wwwassets/script/entryPoint.ts
+++ b/wwwassets/script/entryPoint.ts
@@ -7,9 +7,9 @@ if (typeof window != "undefined") {
 	startApp();
 }
 
-export async function nodeBuild({ucdVersion, emojiVersion, cldrVersion}: {ucdVersion: string, emojiVersion: string, cldrVersion: string}): Promise<ConsolidatedUnicodeData> {
+export async function nodeBuild({ucdVersion, cldrVersion}: {ucdVersion: string, cldrVersion: string}): Promise<ConsolidatedUnicodeData> {
 	const resources: UnicodeResources = {
-		emojiTest: memoizeOne(() => fetch(`https://unicode.org/Public/emoji/${emojiVersion}/emoji-test.txt`).then(r => r.text())),
+		emojiTest: memoizeOne(() => fetch(`https://unicode.org/Public/${ucdVersion}/emoji/emoji-test.txt`).then(r => r.text())),
 		emojiData: memoizeOne(() => fetch(`https://unicode.org/Public/${ucdVersion}/ucd/emoji/emoji-data.txt`).then(r => r.text())),
 		unicodeData: memoizeOne(() => fetch(`https://unicode.org/Public/${ucdVersion}/ucd/UnicodeData.txt`).then(r => r.text())),
 		namesList: memoizeOne(() => fetch(`https://unicode.org/Public/${ucdVersion}/ucd/NamesList.txt`).then(r => r.text())),


### PR DESCRIPTION
- [x] Use new link for [Noto Color Emoji link](https://github.com/google/fonts/raw/refs/heads/main/ofl/notocoloremoji/NotoColorEmoji-Regular.ttf) which still points to the v2.048 instead of the v2.051
- [x] Waiting for the [Unicode CLDR](https://cldr.unicode.org/index/downloads) v48 to be released